### PR TITLE
Wasm function can only trap

### DIFF
--- a/examples/tictactoe.rs
+++ b/examples/tictactoe.rs
@@ -152,12 +152,12 @@ impl<'a> Externals for Runtime<'a> {
 	) -> Result<Option<RuntimeValue>, Trap> {
 		match index {
 			SET_FUNC_INDEX => {
-				let idx: i32 = args.nth(0)?;
+				let idx: i32 = args.nth(0);
 				self.game.set(idx, self.player)?;
 				Ok(None)
 			}
 			GET_FUNC_INDEX => {
-				let idx: i32 = args.nth(0)?;
+				let idx: i32 = args.nth(0);
 				let val: i32 = tictactoe::Player::into_i32(self.game.get(idx)?);
 				Ok(Some(val.into()))
 			}

--- a/examples/tictactoe.rs
+++ b/examples/tictactoe.rs
@@ -8,7 +8,7 @@ use wasmi::{
 	Error as InterpreterError, ModuleInstance, ModuleRef,
 	Externals, RuntimeValue, FuncRef, ModuleImportResolver,
 	FuncInstance, HostError, ImportsBuilder, Signature, ValueType,
-	RuntimeArgs,
+	RuntimeArgs, Trap,
 };
 
 #[derive(Debug)]
@@ -149,7 +149,7 @@ impl<'a> Externals for Runtime<'a> {
 		&mut self,
 		index: usize,
 		args: RuntimeArgs,
-	) -> Result<Option<RuntimeValue>, InterpreterError> {
+	) -> Result<Option<RuntimeValue>, Trap> {
 		match index {
 			SET_FUNC_INDEX => {
 				let idx: i32 = args.nth(0)?;

--- a/src/common/stack.rs
+++ b/src/common/stack.rs
@@ -28,13 +28,6 @@ pub struct StackWithLimit<T> where T: Clone {
 }
 
 impl<T> StackWithLimit<T> where T: Clone {
-	pub fn with_data<D: IntoIterator<Item=T>>(data: D, limit: usize) -> Self {
-		StackWithLimit {
-			values: data.into_iter().collect(),
-			limit: limit
-		}
-	}
-
 	pub fn with_limit(limit: usize) -> Self {
 		StackWithLimit {
 			values: VecDeque::new(),

--- a/src/func.rs
+++ b/src/func.rs
@@ -2,7 +2,7 @@ use std::rc::{Rc, Weak};
 use std::fmt;
 use std::collections::HashMap;
 use parity_wasm::elements::{Local, Opcodes};
-use {Error, Signature};
+use {Trap, Signature};
 use host::Externals;
 use runner::{check_function_args, Interpreter};
 use value::RuntimeValue;
@@ -132,10 +132,10 @@ impl FuncInstance {
 		func: &FuncRef,
 		args: &[RuntimeValue],
 		externals: &mut E,
-	) -> Result<Option<RuntimeValue>, Error> {
+	) -> Result<Option<RuntimeValue>, Trap> {
+		debug_assert!(check_function_args(func.signature(), &args).is_ok());
 		match *func.as_internal() {
-			FuncInstanceInternal::Internal { ref signature, .. } => {
-				check_function_args(signature, &args)?;
+			FuncInstanceInternal::Internal { .. } => {
 				let mut interpreter = Interpreter::new(externals);
 				interpreter.start_execution(func, args)
 			}

--- a/src/host.rs
+++ b/src/host.rs
@@ -26,7 +26,7 @@ impl<'a> RuntimeArgs<'a> {
 	///
 	/// # Errors
 	///
-	/// Returns `Err` if this list have not enough arguments.
+	/// Returns `Err` if this list has not enough arguments.
 	pub fn nth_value_checked(&self, idx: usize) -> Result<RuntimeValue, Error> {
 		if self.0.len() <= idx {
 			return Err(Error::Value("Invalid argument index".to_owned()));

--- a/src/host.rs
+++ b/src/host.rs
@@ -13,12 +13,20 @@ impl<'a> From<&'a [RuntimeValue]> for RuntimeArgs<'a> {
 }
 
 impl<'a> RuntimeArgs<'a> {
-	/// Extract argument by index `idx` returning error if cast is invalid or not enough arguments
+	/// Extract argument by index `idx`.
+	///
+	/// # Errors
+	///
+	/// Returns `Err` if cast is invalid or not enough arguments.
 	pub fn nth_checked<T>(&self, idx: usize) -> Result<T, Error> where RuntimeValue: TryInto<T, Error> {
 		Ok(self.nth_value_checked(idx)?.try_into().map_err(|_| Error::Value("Invalid argument cast".to_owned()))?)
 	}
 
-	/// Extract argument as a runtime value by index `idx` returning error is not enough arguments
+	/// Extract argument as a [`RuntimeValue`] by index `idx`.
+	///
+	/// # Errors
+	///
+	/// Returns `Err` if this list have not enough arguments.
 	pub fn nth_value_checked(&self, idx: usize) -> Result<RuntimeValue, Error> {
 		if self.0.len() <= idx {
 			return Err(Error::Value("Invalid argument index".to_owned()));
@@ -26,6 +34,11 @@ impl<'a> RuntimeArgs<'a> {
 		Ok(self.0[idx])
 	}
 
+	/// Extract argument by index `idx`.
+	///
+	/// # Panics
+	///
+	/// Panics if cast is invalid or not enough arguments.
 	pub fn nth<T>(&self, idx: usize) -> T where RuntimeValue: TryInto<T, Error> {
 		let value = self.nth_value_checked(idx).expect("Invalid argument index");
 		value.try_into().expect("Unexpected argument type")

--- a/src/host.rs
+++ b/src/host.rs
@@ -14,16 +14,21 @@ impl<'a> From<&'a [RuntimeValue]> for RuntimeArgs<'a> {
 
 impl<'a> RuntimeArgs<'a> {
 	/// Extract argument by index `idx` returning error if cast is invalid or not enough arguments
-	pub fn nth<T>(&self, idx: usize) -> Result<T, Error> where RuntimeValue: TryInto<T, Error> {
-		Ok(self.nth_value(idx)?.try_into().map_err(|_| Error::Value("Invalid argument cast".to_owned()))?)
+	pub fn nth_checked<T>(&self, idx: usize) -> Result<T, Error> where RuntimeValue: TryInto<T, Error> {
+		Ok(self.nth_value_checked(idx)?.try_into().map_err(|_| Error::Value("Invalid argument cast".to_owned()))?)
 	}
 
 	/// Extract argument as a runtime value by index `idx` returning error is not enough arguments
-	pub fn nth_value(&self, idx: usize) -> Result<RuntimeValue, Error> {
+	pub fn nth_value_checked(&self, idx: usize) -> Result<RuntimeValue, Error> {
 		if self.0.len() <= idx {
 			return Err(Error::Value("Invalid argument index".to_owned()));
 		}
 		Ok(self.0[idx])
+	}
+
+	pub fn nth<T>(&self, idx: usize) -> T where RuntimeValue: TryInto<T, Error> {
+		let value = self.nth_value_checked(idx).expect("Invalid argument index");
+		value.try_into().expect("Unexpected argument type")
 	}
 
 	/// Total number of arguments
@@ -104,7 +109,7 @@ impl HostError {
 /// ```rust
 /// use wasmi::{
 ///     Externals, RuntimeValue, RuntimeArgs, Error, ModuleImportResolver,
-///     FuncRef, ValueType, Signature, FuncInstance
+///     FuncRef, ValueType, Signature, FuncInstance, Trap,
 /// };
 ///
 /// struct HostExternals {
@@ -118,11 +123,11 @@ impl HostError {
 ///         &mut self,
 ///         index: usize,
 ///         args: RuntimeArgs,
-///     ) -> Result<Option<RuntimeValue>, Error> {
+///     ) -> Result<Option<RuntimeValue>, Trap> {
 ///         match index {
 ///             ADD_FUNC_INDEX => {
-///                 let a: u32 = args.nth(0).unwrap();
-///                 let b: u32 = args.nth(1).unwrap();
+///                 let a: u32 = args.nth(0);
+///                 let b: u32 = args.nth(1);
 ///                 let result = a + b;
 ///
 ///                 Ok(Some(RuntimeValue::I32(result as i32)))
@@ -201,14 +206,14 @@ mod tests {
 	#[test]
 	fn i32_runtime_args() {
 		let args: RuntimeArgs = (&[RuntimeValue::I32(0)][..]).into();
-		let val: i32 = args.nth(0).unwrap();
+		let val: i32 = args.nth_checked(0).unwrap();
 		assert_eq!(val, 0);
 	}
 
 	#[test]
 	fn i64_invalid_arg_cast() {
 		let args: RuntimeArgs = (&[RuntimeValue::I64(90534534545322)][..]).into();
-		assert!(args.nth::<i32>(0).is_err());
+		assert!(args.nth_checked::<i32>(0).is_err());
 	}
 
 	// Tests that `HostError` trait is object safe.

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,6 +1,6 @@
 use std::any::TypeId;
 use value::{RuntimeValue, TryInto};
-use Error;
+use {Error, Trap};
 
 /// Safe wrapper for list of arguments.
 #[derive(Debug)]
@@ -188,7 +188,7 @@ impl Externals for NopExternals {
 		_index: usize,
 		_args: RuntimeArgs,
 	) -> Result<Option<RuntimeValue>, Error> {
-		Err(Error::Trap("invoke index on no-op externals".into()))
+		Err(Error::Trap(Trap::Unreachable))
 	}
 }
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -173,7 +173,7 @@ pub trait Externals {
 		&mut self,
 		index: usize,
 		args: RuntimeArgs,
-	) -> Result<Option<RuntimeValue>, Error>;
+	) -> Result<Option<RuntimeValue>, Trap>;
 }
 
 /// Implementation of [`Externals`] that just traps on [`invoke_index`].
@@ -187,8 +187,8 @@ impl Externals for NopExternals {
 		&mut self,
 		_index: usize,
 		_args: RuntimeArgs,
-	) -> Result<Option<RuntimeValue>, Error> {
-		Err(Error::Trap(Trap::Unreachable))
+	) -> Result<Option<RuntimeValue>, Trap> {
+		Err(Trap::Unreachable)
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,7 @@ pub enum Trap {
 	DivisionByZero,
 	InvalidConversionToInt,
 	StackOverflow,
+	Host(Box<host::HostError>),
 }
 
 /// Internal interpreter error.
@@ -201,6 +202,18 @@ impl error::Error for Error {
 impl<U> From<U> for Error where U: host::HostError + Sized {
 	fn from(e: U) -> Self {
 		Error::Host(Box::new(e))
+	}
+}
+
+impl<U> From<U> for Trap where U: host::HostError + Sized {
+	fn from(e: U) -> Self {
+		Trap::Host(Box::new(e))
+	}
+}
+
+impl From<Trap> for Error {
+	fn from(e: Trap) -> Error {
+		Error::Trap(e)
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,7 @@ use std::collections::HashMap;
 #[derive(Debug)]
 pub enum Trap {
 	Unreachable,
+	MemoryAccessOutOfBounds,
 }
 
 /// Internal interpreter error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,11 @@ use std::fmt;
 use std::error;
 use std::collections::HashMap;
 
+#[derive(Debug)]
+pub enum Trap {
+	Unreachable,
+}
+
 /// Internal interpreter error.
 #[derive(Debug)]
 pub enum Error {
@@ -127,7 +132,7 @@ pub enum Error {
 	/// Value-level error.
 	Value(String),
 	/// Trap.
-	Trap(String),
+	Trap(Trap),
 	/// Custom embedder error.
 	Host(Box<host::HostError>),
 }
@@ -143,7 +148,7 @@ impl Into<String> for Error {
 			Error::Global(s) => s,
 			Error::Stack(s) => s,
 			Error::Value(s) => s,
-			Error::Trap(s) => format!("trap: {}", s),
+			Error::Trap(s) => format!("trap: {:?}", s),
 			Error::Host(e) => format!("user: {}", e),
 		}
 	}
@@ -160,7 +165,7 @@ impl fmt::Display for Error {
 			Error::Global(ref s) => write!(f, "Global: {}", s),
 			Error::Stack(ref s) => write!(f, "Stack: {}", s),
 			Error::Value(ref s) => write!(f, "Value: {}", s),
-			Error::Trap(ref s) => write!(f, "Trap: {}", s),
+			Error::Trap(ref s) => write!(f, "Trap: {:?}", s),
 			Error::Host(ref e) => write!(f, "User: {}", e),
 		}
 	}
@@ -179,7 +184,7 @@ impl error::Error for Error {
 			Error::Global(ref s) => s,
 			Error::Stack(ref s) => s,
 			Error::Value(ref s) => s,
-			Error::Trap(ref s) => s,
+			Error::Trap(_) => "Trap",
 			Error::Host(_) => "Host error",
 		}
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,8 @@ pub enum Trap {
 	TableAccessOutOfBounds,
 	ElemUninitialized,
 	ElemSignatureMismatch,
+	DivisionByZero,
+	InvalidConversionToInt,
 }
 
 /// Internal interpreter error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@ pub enum Trap {
 	ElemSignatureMismatch,
 	DivisionByZero,
 	InvalidConversionToInt,
+	StackOverflow,
 }
 
 /// Internal interpreter error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,9 @@ use std::collections::HashMap;
 pub enum Trap {
 	Unreachable,
 	MemoryAccessOutOfBounds,
+	TableAccessOutOfBounds,
+	ElemUninitialized,
+	ElemSignatureMismatch,
 }
 
 /// Internal interpreter error.

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,3 +1,4 @@
+use runner::check_function_args;
 use Trap;
 use std::rc::Rc;
 use std::cell::RefCell;
@@ -576,7 +577,9 @@ impl ModuleInstance {
 			}
 		};
 
-		FuncInstance::invoke(&func_instance, args, externals).map_err(|t| Error::Trap(t))
+		check_function_args(func_instance.signature(), &args)?;
+		FuncInstance::invoke(&func_instance, args, externals)
+			.map_err(|t| Error::Trap(t))
 	}
 
 	/// Find export by a name.

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,3 +1,4 @@
+use Trap;
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::fmt;
@@ -575,7 +576,7 @@ impl ModuleInstance {
 			}
 		};
 
-		FuncInstance::invoke(&func_instance, args, externals)
+		FuncInstance::invoke(&func_instance, args, externals).map_err(|t| Error::Trap(t))
 	}
 
 	/// Find export by a name.
@@ -608,7 +609,7 @@ impl<'a> NotStartedModuleRef<'a> {
 		&self.instance
 	}
 
-	pub fn run_start<E: Externals>(self, state: &mut E) -> Result<ModuleRef, Error> {
+	pub fn run_start<E: Externals>(self, state: &mut E) -> Result<ModuleRef, Trap> {
 		if let Some(start_fn_idx) = self.loaded_module.module().start_section() {
 			let start_func = self.instance.func_by_index(start_fn_idx).expect(
 				"Due to validation start function should exists",

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -534,7 +534,12 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 
 	fn run_load<T>(&mut self, context: &mut FunctionContext, _align: u32, offset: u32) -> Result<InstructionOutcome, Error>
 		where RuntimeValue: From<T>, T: LittleEndianConvert {
-		let address = effective_address(offset, context.value_stack_mut().pop_as()?)?;
+		let address =
+			effective_address(
+				offset,
+				context.value_stack_mut().pop_as()?
+			)
+			.map_err(Error::Trap)?;
 		let m = context.module()
 			.memory_by_index(DEFAULT_MEMORY_INDEX)
 			.expect("Due to validation memory should exists");
@@ -546,7 +551,12 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 
 	fn run_load_extend<T, U>(&mut self, context: &mut FunctionContext, _align: u32, offset: u32) -> Result<InstructionOutcome, Error>
 		where T: ExtendInto<U>, RuntimeValue: From<U>, T: LittleEndianConvert {
-		let address = effective_address(offset, context.value_stack_mut().pop_as()?)?;
+		let address =
+			effective_address(
+				offset,
+				context.value_stack_mut().pop_as()?
+			)
+			.map_err(Error::Trap)?;
 		let m = context.module()
 			.memory_by_index(DEFAULT_MEMORY_INDEX)
 			.expect("Due to validation memory should exists");
@@ -566,7 +576,12 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 			.value_stack_mut()
 			.pop_as::<T>()
 			.map(|n| n.into_little_endian())?;
-		let address = effective_address(offset, context.value_stack_mut().pop_as::<u32>()?)?;
+		let address =
+			effective_address(
+				offset,
+				context.value_stack_mut().pop_as::<u32>()?
+			)
+			.map_err(Error::Trap)?;
 
 		let m = context.module()
 			.memory_by_index(DEFAULT_MEMORY_INDEX)
@@ -592,7 +607,12 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 			.map_err(Into::into)
 			.and_then(|v| v.try_into())?;
 		let stack_value = stack_value.wrap_into().into_little_endian();
-		let address = effective_address(offset, context.value_stack_mut().pop_as::<u32>()?)?;
+		let address =
+			effective_address(
+				offset,
+				context.value_stack_mut().pop_as::<u32>()?
+			)
+			.map_err(Error::Trap)?;
 		let m = context.module()
 			.memory_by_index(DEFAULT_MEMORY_INDEX)
 			.expect("Due to validation memory should exists");
@@ -1147,9 +1167,9 @@ impl fmt::Debug for FunctionContext {
 	}
 }
 
-fn effective_address(address: u32, offset: u32) -> Result<u32, Error> {
+fn effective_address(address: u32, offset: u32) -> Result<u32, Trap> {
 	match offset.checked_add(address) {
-		None => Err(Error::Memory(format!("invalid memory access: {} + {}", offset, address))),
+		None => Err(Trap::MemoryAccessOutOfBounds),
 		Some(address) => Ok(address),
 	}
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -486,9 +486,9 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 	}
 
 	fn run_get_local(&mut self, context: &mut FunctionContext, index: u32) -> Result<InstructionOutcome, Error> {
-		context.get_local(index as usize)
-			.map(|value| context.value_stack_mut().push(value))
-			.map(|_| InstructionOutcome::RunNextInstruction)
+		let value = context.get_local(index as usize);
+		context.value_stack_mut().push(value)?;
+		Ok(InstructionOutcome::RunNextInstruction)
 	}
 
 	fn run_set_local(&mut self, context: &mut FunctionContext, index: u32) -> Result<InstructionOutcome, Error> {
@@ -1071,10 +1071,10 @@ impl FunctionContext {
 		Ok(InstructionOutcome::RunNextInstruction)
 	}
 
-	pub fn get_local(&mut self, index: usize) -> Result<RuntimeValue, Error> {
-		Ok(self.locals.get(index)
+	pub fn get_local(&mut self, index: usize) -> RuntimeValue {
+		self.locals.get(index)
 			.cloned()
-			.expect("Due to validation local should exists"))
+			.expect("Due to validation local should exists")
 	}
 
 	pub fn value_stack(&self) -> &StackWithLimit<RuntimeValue> {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -791,7 +791,7 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 			.value_stack_mut()
 			.pop_pair_as::<T>()
 			.map(|(left, right)| (left.transmute_into(), right.transmute_into()))
-			.map(|(left, right)| left.div(right))?
+			.map(|(left, right)| left.div(right).map_err(|_| Error::Trap(Trap::DivisionByZero)))?
 			.map(|v| v.transmute_into())
 			.map(|v| context.value_stack_mut().push(v.into()))
 			.map(|_| InstructionOutcome::RunNextInstruction)
@@ -803,7 +803,7 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 			.value_stack_mut()
 			.pop_pair_as::<T>()
 			.map(|(left, right)| (left.transmute_into(), right.transmute_into()))
-			.map(|(left, right)| left.rem(right))?
+			.map(|(left, right)| left.rem(right).map_err(|_| Error::Trap(Trap::DivisionByZero)))?
 			.map(|v| v.transmute_into())
 			.map(|v| context.value_stack_mut().push(v.into()))
 			.map(|_| InstructionOutcome::RunNextInstruction)
@@ -996,7 +996,7 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 		context
 			.value_stack_mut()
 			.pop_as::<T>()
-			.and_then(|v| v.try_truncate_into())
+			.and_then(|v| v.try_truncate_into().map_err(|_| Error::Trap(Trap::InvalidConversionToInt)))
 			.map(|v| v.transmute_into())
 			.map(|v| context.value_stack_mut().push(v.into()))
 			.map(|_| InstructionOutcome::RunNextInstruction)

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -5,7 +5,7 @@ use std::fmt::{self, Display};
 use std::iter::repeat;
 use std::collections::{HashMap, VecDeque};
 use parity_wasm::elements::{Opcode, BlockType, Local};
-use {Error, Signature};
+use {Error, Trap, Signature};
 use module::ModuleRef;
 use func::{FuncRef, FuncInstance, FuncInstanceInternal};
 use value::{
@@ -351,7 +351,7 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 	}
 
 	fn run_unreachable(&mut self, _context: &mut FunctionContext) -> Result<InstructionOutcome, Error> {
-		Err(Error::Trap("programmatic".into()))
+		Err(Error::Trap(Trap::Unreachable))
 	}
 
 	fn run_nop(&mut self, _context: &mut FunctionContext) -> Result<InstructionOutcome, Error> {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -369,8 +369,11 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 	}
 
 	fn run_if(&mut self, context: &mut FunctionContext, labels: &HashMap<usize, usize>, block_type: BlockType) -> Result<InstructionOutcome, Error> {
-		let branch = context.value_stack_mut().pop_as()?;
-		let block_frame_type = if branch { BlockFrameType::IfTrue } else {
+		let condition: bool = context
+			.value_stack_mut()
+			.pop_as()
+			.expect("Due to validation stack top should be an int");
+		let block_frame_type = if condition { BlockFrameType::IfTrue } else {
 			let else_pos = labels[&context.position];
 			if !labels.contains_key(&else_pos) {
 				context.position = else_pos;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -791,7 +791,7 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 			.value_stack_mut()
 			.pop_pair_as::<T>()
 			.map(|(left, right)| (left.transmute_into(), right.transmute_into()))
-			.map(|(left, right)| left.div(right).map_err(|_| Error::Trap(Trap::DivisionByZero)))?
+			.map(|(left, right)| left.div(right).map_err(Error::Trap))?
 			.map(|v| v.transmute_into())
 			.map(|v| context.value_stack_mut().push(v.into()))
 			.map(|_| InstructionOutcome::RunNextInstruction)
@@ -803,7 +803,7 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 			.value_stack_mut()
 			.pop_pair_as::<T>()
 			.map(|(left, right)| (left.transmute_into(), right.transmute_into()))
-			.map(|(left, right)| left.rem(right).map_err(|_| Error::Trap(Trap::DivisionByZero)))?
+			.map(|(left, right)| left.rem(right).map_err(Error::Trap))?
 			.map(|v| v.transmute_into())
 			.map(|v| context.value_stack_mut().push(v.into()))
 			.map(|_| InstructionOutcome::RunNextInstruction)
@@ -992,11 +992,11 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 	}
 
 	fn run_trunc_to_int<T, U, V>(&mut self, context: &mut FunctionContext) -> Result<InstructionOutcome, Error>
-		where RuntimeValue: From<V> + TryInto<T, Error>, T: TryTruncateInto<U, Error>, U: TransmuteInto<V>,  {
+		where RuntimeValue: From<V> + TryInto<T, Error>, T: TryTruncateInto<U, Trap>, U: TransmuteInto<V>,  {
 		context
 			.value_stack_mut()
 			.pop_as::<T>()
-			.and_then(|v| v.try_truncate_into().map_err(|_| Error::Trap(Trap::InvalidConversionToInt)))
+			.and_then(|v| v.try_truncate_into().map_err(Error::Trap))
 			.map(|v| v.transmute_into())
 			.map(|v| context.value_stack_mut().push(v.into()))
 			.map(|_| InstructionOutcome::RunNextInstruction)

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -470,11 +470,10 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 			.value_stack_mut()
 			.pop_triple()
 			.and_then(|(left, mid, right)| {
-				let right: Result<_, Error> = right.try_into();
-				match (left, mid, right) {
-					(left, mid, Ok(condition)) => Ok((left, mid, condition)),
-					_ => Err(Error::Stack("expected to get int value from stack".into()))
-				}
+				let condition = right
+					.try_into()
+					.expect("Due to validation stack top should be int");
+				Ok((left, mid, condition))
 			})
 			.map(|(left, mid, condition)| if condition { left } else { mid })
 			.map(|val| context.value_stack_mut().push(val))

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -544,7 +544,7 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 			.memory_by_index(DEFAULT_MEMORY_INDEX)
 			.expect("Due to validation memory should exists");
 		let b = m.get(address, mem::size_of::<T>())?;
-		let n = T::from_little_endian(b)?;
+		let n = T::from_little_endian(&b)?;
 		context.value_stack_mut().push(n.into())?;
 		Ok(InstructionOutcome::RunNextInstruction)
 	}
@@ -561,7 +561,7 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 			.memory_by_index(DEFAULT_MEMORY_INDEX)
 			.expect("Due to validation memory should exists");
 		let b = m.get(address, mem::size_of::<T>())?;
-		let v = T::from_little_endian(b)?;
+		let v = T::from_little_endian(&b)?;
 		let stack_value: U = v.extend_into();
 		context
 			.value_stack_mut()

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -543,7 +543,8 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 		let m = context.module()
 			.memory_by_index(DEFAULT_MEMORY_INDEX)
 			.expect("Due to validation memory should exists");
-		let b = m.get(address, mem::size_of::<T>())?;
+		let b = m.get(address, mem::size_of::<T>())
+			.map_err(|_| Error::Trap(Trap::MemoryAccessOutOfBounds))?;
 		let n = T::from_little_endian(&b)?;
 		context.value_stack_mut().push(n.into())?;
 		Ok(InstructionOutcome::RunNextInstruction)
@@ -560,7 +561,8 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 		let m = context.module()
 			.memory_by_index(DEFAULT_MEMORY_INDEX)
 			.expect("Due to validation memory should exists");
-		let b = m.get(address, mem::size_of::<T>())?;
+		let b = m.get(address, mem::size_of::<T>())
+			.map_err(|_| Error::Trap(Trap::MemoryAccessOutOfBounds))?;
 		let v = T::from_little_endian(&b)?;
 		let stack_value: U = v.extend_into();
 		context
@@ -586,7 +588,8 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 		let m = context.module()
 			.memory_by_index(DEFAULT_MEMORY_INDEX)
 			.expect("Due to validation memory should exists");
-		m.set(address, &stack_value)?;
+		m.set(address, &stack_value)
+			.map_err(|_| Error::Trap(Trap::MemoryAccessOutOfBounds))?;
 		Ok(InstructionOutcome::RunNextInstruction)
 	}
 
@@ -616,7 +619,8 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 		let m = context.module()
 			.memory_by_index(DEFAULT_MEMORY_INDEX)
 			.expect("Due to validation memory should exists");
-		m.set(address, &stack_value)?;
+		m.set(address, &stack_value)
+			.map_err(|_| Error::Trap(Trap::MemoryAccessOutOfBounds))?;
 		Ok(InstructionOutcome::RunNextInstruction)
 	}
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -545,7 +545,8 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 			.expect("Due to validation memory should exists");
 		let b = m.get(address, mem::size_of::<T>())
 			.map_err(|_| Error::Trap(Trap::MemoryAccessOutOfBounds))?;
-		let n = T::from_little_endian(&b)?;
+		let n = T::from_little_endian(&b)
+			.expect("Can't fail since buffer length should be size_of::<T>");
 		context.value_stack_mut().push(n.into())?;
 		Ok(InstructionOutcome::RunNextInstruction)
 	}
@@ -563,7 +564,8 @@ impl<'a, E: Externals> Interpreter<'a, E> {
 			.expect("Due to validation memory should exists");
 		let b = m.get(address, mem::size_of::<T>())
 			.map_err(|_| Error::Trap(Trap::MemoryAccessOutOfBounds))?;
-		let v = T::from_little_endian(&b)?;
+		let v = T::from_little_endian(&b)
+			.expect("Can't fail since buffer length should be size_of::<T>");
 		let stack_value: U = v.extend_into();
 		context
 			.value_stack_mut()

--- a/src/table.rs
+++ b/src/table.rs
@@ -107,7 +107,7 @@ impl TableInstance {
 	}
 
 	/// Get the specific value in the table
-	pub fn get(&self, offset: u32) -> Result<FuncRef, Error> {
+	pub fn get(&self, offset: u32) -> Result<Option<FuncRef>, Error> {
 		let buffer = self.buffer.borrow();
 		let buffer_len = buffer.len();
 		let table_elem = buffer.get(offset as usize).cloned().ok_or_else(||
@@ -117,10 +117,7 @@ impl TableInstance {
 				buffer_len
 			)),
 		)?;
-		Ok(table_elem.ok_or_else(|| Error::Table(format!(
-			"trying to read uninitialized element on index {}",
-			offset
-		)))?)
+		Ok(table_elem)
 	}
 
 	/// Set the table element to the specified function.

--- a/src/tests/host.rs
+++ b/src/tests/host.rs
@@ -82,20 +82,20 @@ impl Externals for TestHost {
 	) -> Result<Option<RuntimeValue>, Trap> {
 		match index {
 			SUB_FUNC_INDEX => {
-				let a: i32 = args.nth(0)?;
-				let b: i32 = args.nth(1)?;
+				let a: i32 = args.nth(0);
+				let b: i32 = args.nth(1);
 
 				let result: RuntimeValue = (a - b).into();
 
 				Ok(Some(result))
 			}
 			ERR_FUNC_INDEX => {
-				let error_code: u32 = args.nth(0)?;
+				let error_code: u32 = args.nth(0);
 				let error = HostErrorWithCode { error_code };
-				Err(Error::Host(Box::new(error)))
+				Err(Trap::Host(Box::new(error)))
 			}
 			INC_MEM_FUNC_INDEX => {
-				let ptr: u32 = args.nth(0)?;
+				let ptr: u32 = args.nth(0);
 
 				let memory = self.memory.as_ref().expect(
 					"Function 'inc_mem' expects attached memory",
@@ -108,7 +108,7 @@ impl Externals for TestHost {
 				Ok(None)
 			}
 			GET_MEM_FUNC_INDEX => {
-				let ptr: u32 = args.nth(0)?;
+				let ptr: u32 = args.nth(0);
 
 				let memory = self.memory.as_ref().expect(
 					"Function 'get_mem' expects attached memory",
@@ -119,7 +119,7 @@ impl Externals for TestHost {
 				Ok(Some(RuntimeValue::I32(buf[0] as i32)))
 			}
 			RECURSE_FUNC_INDEX => {
-				let val = args.nth_value(0)?;
+				let val = args.nth_value_checked(0).expect("Exactly one argument expected");
 
 				let instance = self.instance
 					.as_ref()
@@ -131,7 +131,7 @@ impl Externals for TestHost {
 					.expect("expected to be Some");
 
 				if val.value_type() != result.value_type() {
-					return Err(Error::Host(Box::new(HostErrorWithCode { error_code: 123 })));
+					return Err(Trap::Host(Box::new(HostErrorWithCode { error_code: 123 })));
 				}
 				Ok(Some(result))
 			}
@@ -263,7 +263,7 @@ fn host_err() {
 	);
 
 	let host_error: Box<HostError> = match error {
-		Error::Host(err) => err,
+		Error::Trap(Trap::Host(err)) => err,
 		err => panic!("Unexpected error {:?}", err),
 	};
 
@@ -467,7 +467,7 @@ fn defer_providing_externals() {
 		) -> Result<Option<RuntimeValue>, Trap> {
 			match index {
 				INC_FUNC_INDEX => {
-					let a = args.nth::<u32>(0)?;
+					let a = args.nth::<u32>(0);
 					*self.acc += a;
 					Ok(None)
 				}
@@ -661,7 +661,8 @@ fn dynamically_add_host_func() {
 						Signature::new(&[][..], Some(ValueType::I32)),
 						host_func_index as usize,
 					);
-					self.table.set(table_index, Some(added_func))?;
+					self.table.set(table_index, Some(added_func))
+						.map_err(|_| Trap::TableAccessOutOfBounds)?;
 
 					Ok(Some(RuntimeValue::I32(table_index as i32)))
 				}

--- a/src/tests/host.rs
+++ b/src/tests/host.rs
@@ -1,7 +1,7 @@
 use {
 	Error, Signature, Externals, FuncInstance, FuncRef, HostError, ImportsBuilder,
 	MemoryInstance, MemoryRef, TableInstance, TableRef, ModuleImportResolver, ModuleInstance, ModuleRef,
-	RuntimeValue, RuntimeArgs, Module, TableDescriptor, MemoryDescriptor,
+	RuntimeValue, RuntimeArgs, Module, TableDescriptor, MemoryDescriptor, Trap,
 };
 use types::ValueType;
 use wabt::wat2wasm;
@@ -79,7 +79,7 @@ impl Externals for TestHost {
 		&mut self,
 		index: usize,
 		args: RuntimeArgs,
-	) -> Result<Option<RuntimeValue>, Error> {
+	) -> Result<Option<RuntimeValue>, Trap> {
 		match index {
 			SUB_FUNC_INDEX => {
 				let a: i32 = args.nth(0)?;
@@ -464,7 +464,7 @@ fn defer_providing_externals() {
 			&mut self,
 			index: usize,
 			args: RuntimeArgs,
-		) -> Result<Option<RuntimeValue>, Error> {
+		) -> Result<Option<RuntimeValue>, Trap> {
 			match index {
 				INC_FUNC_INDEX => {
 					let a = args.nth::<u32>(0)?;
@@ -528,7 +528,7 @@ fn two_envs_one_externals() {
 			&mut self,
 			index: usize,
 			_args: RuntimeArgs,
-		) -> Result<Option<RuntimeValue>, Error> {
+		) -> Result<Option<RuntimeValue>, Trap> {
 			match index {
 				PRIVILEGED_FUNC_INDEX => {
 					println!("privileged!");
@@ -648,7 +648,7 @@ fn dynamically_add_host_func() {
 			&mut self,
 			index: usize,
 			_args: RuntimeArgs,
-		) -> Result<Option<RuntimeValue>, Error> {
+		) -> Result<Option<RuntimeValue>, Trap> {
 			match index {
 				ADD_FUNC_FUNC_INDEX => {
 					// Allocate indicies for the new function.

--- a/src/value.rs
+++ b/src/value.rs
@@ -53,7 +53,7 @@ pub trait LittleEndianConvert where Self: Sized {
 	/// Convert to little endian buffer.
 	fn into_little_endian(self) -> Vec<u8>;
 	/// Convert from little endian buffer.
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error>;
+	fn from_little_endian(buffer: &[u8]) -> Result<Self, Error>;
 }
 
 /// Arithmetic operations.
@@ -376,7 +376,7 @@ impl LittleEndianConvert for i8 {
 		vec![self as u8]
 	}
 
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error> {
+	fn from_little_endian(buffer: &[u8]) -> Result<Self, Error> {
 		buffer.get(0)
 			.map(|v| *v as i8)
 			.ok_or_else(|| Error::Value("invalid little endian buffer".into()))
@@ -388,7 +388,7 @@ impl LittleEndianConvert for u8 {
 		vec![self]
 	}
 
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error> {
+	fn from_little_endian(buffer: &[u8]) -> Result<Self, Error> {
 		buffer.get(0)
 			.cloned()
 			.ok_or_else(|| Error::Value("invalid little endian buffer".into()))
@@ -403,7 +403,7 @@ impl LittleEndianConvert for i16 {
 		vec
 	}
 
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error> {
+	fn from_little_endian(buffer: &[u8]) -> Result<Self, Error> {
 		io::Cursor::new(buffer).read_i16::<LittleEndian>()
 			.map_err(|e| Error::Value(e.to_string()))
 	}
@@ -417,7 +417,7 @@ impl LittleEndianConvert for u16 {
 		vec
 	}
 
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error> {
+	fn from_little_endian(buffer: &[u8]) -> Result<Self, Error> {
 		io::Cursor::new(buffer).read_u16::<LittleEndian>()
 			.map_err(|e| Error::Value(e.to_string()))
 	}
@@ -431,7 +431,7 @@ impl LittleEndianConvert for i32 {
 		vec
 	}
 
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error> {
+	fn from_little_endian(buffer: &[u8]) -> Result<Self, Error> {
 		io::Cursor::new(buffer).read_i32::<LittleEndian>()
 			.map_err(|e| Error::Value(e.to_string()))
 	}
@@ -445,7 +445,7 @@ impl LittleEndianConvert for u32 {
 		vec
 	}
 
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error> {
+	fn from_little_endian(buffer: &[u8]) -> Result<Self, Error> {
 		io::Cursor::new(buffer).read_u32::<LittleEndian>()
 			.map_err(|e| Error::Value(e.to_string()))
 	}
@@ -459,7 +459,7 @@ impl LittleEndianConvert for i64 {
 		vec
 	}
 
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error> {
+	fn from_little_endian(buffer: &[u8]) -> Result<Self, Error> {
 		io::Cursor::new(buffer).read_i64::<LittleEndian>()
 			.map_err(|e| Error::Value(e.to_string()))
 	}
@@ -473,7 +473,7 @@ impl LittleEndianConvert for f32 {
 		vec
 	}
 
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error> {
+	fn from_little_endian(buffer: &[u8]) -> Result<Self, Error> {
 		io::Cursor::new(buffer).read_u32::<LittleEndian>()
 			.map(f32_from_bits)
 			.map_err(|e| Error::Value(e.to_string()))
@@ -488,7 +488,7 @@ impl LittleEndianConvert for f64 {
 		vec
 	}
 
-	fn from_little_endian(buffer: Vec<u8>) -> Result<Self, Error> {
+	fn from_little_endian(buffer: &[u8]) -> Result<Self, Error> {
 		io::Cursor::new(buffer).read_u64::<LittleEndian>()
 			.map(f64_from_bits)
 			.map_err(|e| Error::Value(e.to_string()))


### PR DESCRIPTION
Wasm function can fail only by trapping (e.g. invoking wasm function can't result in linkage error). This means we can benefit from introducing special error type for traps.