### PR TITLE
Publish LINEAR_MEMORY_PAGE_SIZE constant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,7 @@ mod types;
 #[cfg(test)]
 mod tests;
 
-pub use self::memory::{MemoryInstance, MemoryRef};
+pub use self::memory::{MemoryInstance, MemoryRef, LINEAR_MEMORY_PAGE_SIZE};
 pub use self::table::{TableInstance, TableRef};
 pub use self::value::RuntimeValue;
 pub use self::host::{Externals, NopExternals, HostError, RuntimeArgs};

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -8,8 +8,13 @@ use parity_wasm::elements::ResizableLimits;
 use Error;
 use module::check_limits;
 
-/// Linear memory page size.
+/// Size of a page of [linear memory][`MemoryInstance`] - 64KiB.
+///
+/// The size of a memory is always a integer multiple of a page size.
+///
+/// [`MemoryInstance`]: struct.MemoryInstance.html
 pub const LINEAR_MEMORY_PAGE_SIZE: u32 = 65536;
+
 /// Maximal number of pages.
 const LINEAR_MEMORY_MAX_PAGES: u32 = 65536;
 


### PR DESCRIPTION
This constant might be useful for users of wasmi