### PR TITLE
Just bump framestack limits.

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -6,10 +6,6 @@ pub mod stack;
 pub const DEFAULT_MEMORY_INDEX: u32 = 0;
 /// Index of default table.
 pub const DEFAULT_TABLE_INDEX: u32 = 0;
-/// Maximum number of entries in value stack.
-pub const DEFAULT_VALUE_STACK_LIMIT: usize = 16384;
-/// Maximum number of entries in frame stack.
-pub const DEFAULT_FRAME_STACK_LIMIT: usize = 1024;
 
 /// Control stack frame.
 #[derive(Debug, Clone)]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -15,8 +15,12 @@ use value::{
 use host::Externals;
 use common::{DEFAULT_MEMORY_INDEX, DEFAULT_TABLE_INDEX, BlockFrame, BlockFrameType};
 use common::stack::StackWithLimit;
-use common::{DEFAULT_FRAME_STACK_LIMIT, DEFAULT_VALUE_STACK_LIMIT};
 use memory_units::Pages;
+
+/// Maximum number of entries in value stack.
+pub const DEFAULT_VALUE_STACK_LIMIT: usize = 16384;
+/// Maximum number of entries in frame stack.
+pub const DEFAULT_FRAME_STACK_LIMIT: usize = 16384;
 
 /// Function interpreter.
 pub struct Interpreter<'a, E: Externals + 'a> {

--- a/src/validation/func.rs
+++ b/src/validation/func.rs
@@ -10,10 +10,10 @@ use validation::Error;
 use common::stack::StackWithLimit;
 use common::{BlockFrame, BlockFrameType};
 
-/// Maximum number of entries in value stack.
+/// Maximum number of entries in value stack per function.
 const DEFAULT_VALUE_STACK_LIMIT: usize = 16384;
-/// Maximum number of entries in frame stack.
-const DEFAULT_FRAME_STACK_LIMIT: usize = 1024;
+/// Maximum number of entries in frame stack per function.
+const DEFAULT_FRAME_STACK_LIMIT: usize = 16384;
 
 /// Function validation context.
 struct FunctionValidationContext<'a> {


### PR DESCRIPTION
These limits seems to be picked arbitrary, and I just made it arbitrary larger.

Anyway, we need to reconsider these limits, ideally providing to the user a way to customize the limits. (#51)

FWIW, When the last time I've tried to run gcc's torture testsuite with wasmi it also bumped into this limit.

Fixes #41.