### PR TITLE
Use wasmi ValueType for RuntimeValue instead pwasm

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1101,6 +1101,7 @@ impl FunctionContext {
 
 		let locals = locals.iter()
 			.flat_map(|l| repeat(l.value_type()).take(l.count() as usize))
+			.map(::types::ValueType::from_elements)
 			.map(RuntimeValue::default)
 			.collect::<Vec<_>>();
 		self.locals.extend(locals);

--- a/src/value.rs
+++ b/src/value.rs
@@ -123,12 +123,12 @@ pub trait Float<T>: ArithmeticOps<T> {
 
 impl RuntimeValue {
 	/// Creates new default value of given type.
-	pub fn default(value_type: ValueType) -> Self {
+	pub fn default(value_type: ::types::ValueType) -> Self {
 		match value_type {
-			ValueType::I32 => RuntimeValue::I32(0),
-			ValueType::I64 => RuntimeValue::I64(0),
-			ValueType::F32 => RuntimeValue::F32(0f32),
-			ValueType::F64 => RuntimeValue::F64(0f64),
+			::types::ValueType::I32 => RuntimeValue::I32(0),
+			::types::ValueType::I64 => RuntimeValue::I64(0),
+			::types::ValueType::F32 => RuntimeValue::F32(0f32),
+			::types::ValueType::F64 => RuntimeValue::F64(0f64),
 		}
 	}
 


### PR DESCRIPTION
`RuntimeValue::default` takes `parity_wasm::elements::ValueType` as an input parameter. This change fixes it to be wasmi's `ValueType`.