### PR TITLE
Add `instantiate` bin

### DIFF
--- a/src/bin/instantiate.rs
+++ b/src/bin/instantiate.rs
@@ -1,0 +1,81 @@
+//! Handy utility to test whether the given module deserializes,
+//! validates and instantiates successfully.
+
+extern crate wasmi;
+
+use std::env::args;
+use std::fs::File;
+use wasmi::{
+	Error, FuncInstance, FuncRef, GlobalDescriptor, GlobalInstance, GlobalRef,
+	ImportsBuilder, MemoryDescriptor, MemoryInstance, MemoryRef, Module,
+	ModuleImportResolver, ModuleInstance, NopExternals, RuntimeValue, Signature,
+	TableDescriptor, TableInstance, TableRef};
+use wasmi::memory_units::*;
+
+fn load_from_file(filename: &str) -> Module {
+	use std::io::prelude::*;
+	let mut file = File::open(filename).unwrap();
+	let mut buf = Vec::new();
+	file.read_to_end(&mut buf).unwrap();
+	Module::from_buffer(buf).unwrap()
+}
+
+struct ResolveAll;
+
+impl ModuleImportResolver for ResolveAll {
+	fn resolve_func(&self, _field_name: &str, signature: &Signature) -> Result<FuncRef, Error> {
+		Ok(FuncInstance::alloc_host(signature.clone(), 0))
+	}
+
+	fn resolve_global(
+		&self,
+		_field_name: &str,
+		global_type: &GlobalDescriptor,
+	) -> Result<GlobalRef, Error> {
+		Ok(GlobalInstance::alloc(
+			RuntimeValue::default(global_type.value_type()),
+			global_type.is_mutable(),
+		))
+	}
+
+	fn resolve_memory(
+		&self,
+		_field_name: &str,
+		memory_type: &MemoryDescriptor,
+	) -> Result<MemoryRef, Error> {
+		Ok(MemoryInstance::alloc(
+			Pages(memory_type.initial() as usize),
+			memory_type.maximum().map(|m| Pages(m as usize)),
+		).unwrap())
+	}
+
+	fn resolve_table(
+		&self,
+		_field_name: &str,
+		table_type: &TableDescriptor,
+	) -> Result<TableRef, Error> {
+		Ok(TableInstance::alloc(table_type.initial(), table_type.maximum()).unwrap())
+	}
+}
+
+fn main() {
+	let args: Vec<_> = args().collect();
+	if args.len() != 2 {
+		println!("Usage: {} <wasm file>", args[0]);
+		return;
+	}
+	let module = load_from_file(&args[1]);
+	let _ = ModuleInstance::new(
+		&module,
+		&ImportsBuilder::default()
+			// Well known imports.
+			.with_resolver("env", &ResolveAll)
+			.with_resolver("global", &ResolveAll)
+			.with_resolver("foo", &ResolveAll)
+			.with_resolver("global.Math", &ResolveAll)
+			.with_resolver("asm2wasm", &ResolveAll)
+			.with_resolver("spectest", &ResolveAll),
+	).expect("Failed to instantiate module")
+		.run_start(&mut NopExternals)
+		.expect("Failed to run start function in module");
+}

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1101,6 +1101,7 @@ impl FunctionContext {
 
 		let locals = locals.iter()
 			.flat_map(|l| repeat(l.value_type()).take(l.count() as usize))
+			.map(::types::ValueType::from_elements)
 			.map(RuntimeValue::default)
 			.collect::<Vec<_>>();
 		self.locals.extend(locals);

--- a/src/value.rs
+++ b/src/value.rs
@@ -123,12 +123,12 @@ pub trait Float<T>: ArithmeticOps<T> {
 
 impl RuntimeValue {
 	/// Creates new default value of given type.
-	pub fn default(value_type: ValueType) -> Self {
+	pub fn default(value_type: ::types::ValueType) -> Self {
 		match value_type {
-			ValueType::I32 => RuntimeValue::I32(0),
-			ValueType::I64 => RuntimeValue::I64(0),
-			ValueType::F32 => RuntimeValue::F32(0f32),
-			ValueType::F64 => RuntimeValue::F64(0f64),
+			::types::ValueType::I32 => RuntimeValue::I32(0),
+			::types::ValueType::I64 => RuntimeValue::I64(0),
+			::types::ValueType::F32 => RuntimeValue::F32(0f32),
+			::types::ValueType::F64 => RuntimeValue::F64(0f64),
 		}
 	}
 


### PR DESCRIPTION
This change depends on #52.

This change adds a handy utility to test whether the given module deserializes, validates and instantiates successfully.